### PR TITLE
Escape special chars in topic and skip mono

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -154,7 +154,12 @@ class Bot:
         request = requests.head(link)
 
         if request.ok:
-            text += "* [`{}`]({}) in _{}.txt_\n".format(topic, link, doc)
+            escaped, count = re.subn(r"([\[\]`])", r"\\\1", topic)
+            if count > 0:
+                topic = escaped
+                text += "* [{}]({}) in _{}.txt_\n".format(topic, link, doc)
+            else:
+                text += "* [`{}`]({}) in _{}.txt_\n".format(topic, link, doc)
         return text
 
     def start(self):

--- a/test_bot.py
+++ b/test_bot.py
@@ -44,6 +44,29 @@ class TestBot(unittest.TestCase):
             best_tag = next(iter(result.keys()))[1]
             self.assertEqual(best_tag, v)
 
+    def test_difficult_markdown(self):
+        """
+        Test that bot falls back to simpler formatting for difficult markdown.
+        """
+
+        tests = [
+            {"topic": ":make",           "link": r"[`:make`]"},
+            {"topic": "[I",              "link": r"[\[I]"},
+            {"topic": "[_CTRL-I",        "link": r"[\[_CTRL-I]"},
+            {"topic": "`]",              "link": r"[\`\]]"},
+            {"topic": "c_CTRL-F",        "link": r"[`c_CTRL-F`]"},
+            {"topic": "c_CTRL-G",        "link": r"[`c_CTRL-G`]"},
+            {"topic": "c_CTRL-L",        "link": r"[`c_CTRL-L`]"},
+            {"topic": "c_CTRL-R_CTRL-W", "link": r"[`c_CTRL-R_CTRL-W`]"},
+            {"topic": "pattern.txt",     "link": r"[`pattern.txt`]"},
+            {"topic": "search()",        "link": r"[`search"},
+        ]
+
+        bot = Bot()
+        for t in tests:
+            reply = bot.create_comment("`:h {}`".format(t["topic"]), None, "vim")
+            self.assertIn(t["link"], reply)
+
     def test_empty_comment(self):
         """
         Test comment is empty if nothing is found


### PR DESCRIPTION
Fix #36.

If the topic contains chars that make markdown formatting difficult (`[` `]` `), escape them and omit fixed width styling.

Markdown parsers are often inconsistent, so hopefully simpler markdown is more likely to display properly for more users.

Never deployed, but I've tested the code separately based on some examples from #36. I don't know what actual values pop out of the db for `topic` -- I've guessed them based on vimhelpbot's responses.

My test code:

```
import re

tests = [
    {
        "topic": "`]",
        "link": "https://vimhelp.org/motion.txt.html#%60%5D",
        "doc": "motion",
    },
    {
        "topic": ":make",
        "link": "https://neovim.io/doc/user/quickfix.html#%3Amake",
        "doc": "quickfix",
    },
    {
        "topic": "c_CTRL-G",
        "link": "https://vimhelp.org/cmdline.txt.html#c_CTRL-G",
        "doc": "cmdline",
    },
    {
        "topic": "c_CTRL-L",
        "link": "https://vimhelp.org/cmdline.txt.html#c_CTRL-L",
        "doc": "cmdline",
    },
    {
        "topic": "pattern.txt",
        "link": "https://vimhelp.org/pattern.txt.html#pattern.txt",
        "doc": "pattern",
    },
    {
        "topic": "c_CTRL-F",
        "link": "https://vimhelp.org/cmdline.txt.html#c_CTRL-F",
        "doc": "cmdline",
    },
    {
        "topic": "search()",
        "link": "https://vimhelp.org/eval.txt.html#search%28%29",
        "doc": "eval",
    },
    {
        "topic": "c_CTRL-R_CTRL-W",
        "link": "https://vimhelp.org/cmdline.txt.html#c_CTRL-R_CTRL-W",
        "doc": "cmdline",
    },
    {
        "topic": "[I",
        "link": "https://vimhelp.org/tagsrch.txt.html#%5BI",
        "doc": "tagsrch",
    },
    {
        "topic": "[_CTRL-I",
        "link": "https://vimhelp.org/tagsrch.txt.html#%5B_CTRL-I",
        "doc": "tagsrch",
    },
]



for t in tests:
    topic = t["topic"]
    link = t["link"]
    doc = t["doc"]

    text = ""
    escaped, count = re.subn(r"([\[\]`])", r"\\\1", topic)
    if count > 0:
        topic = escaped
        text += "* [{}]({}) in _{}.txt_\n".format(topic, link, doc)
    else:
        text += "* [`{}`]({}) in _{}.txt_\n".format(topic, link, doc)

    print(text)
```

Which produces results that [look okay on old reddit](https://old.reddit.com/r/vim/comments/m736j3/how_do_people_move_vertically/irhttul/) and [new reddit](https://new.reddit.com/r/vim/comments/m736j3/how_do_people_move_vertically/irhttul/):

```
* [\`\]](https://vimhelp.org/motion.txt.html#%60%5D) in _motion.txt_
* [`:make`](https://neovim.io/doc/user/quickfix.html#%3Amake) in _quickfix.txt_
* [`c_CTRL-G`](https://vimhelp.org/cmdline.txt.html#c_CTRL-G) in _cmdline.txt_
* [`c_CTRL-L`](https://vimhelp.org/cmdline.txt.html#c_CTRL-L) in _cmdline.txt_
* [`pattern.txt`](https://vimhelp.org/pattern.txt.html#pattern.txt) in _pattern.txt_
* [`c_CTRL-F`](https://vimhelp.org/cmdline.txt.html#c_CTRL-F) in _cmdline.txt_
* [`search()`](https://vimhelp.org/eval.txt.html#search%28%29) in _eval.txt_
* [`c_CTRL-R_CTRL-W`](https://vimhelp.org/cmdline.txt.html#c_CTRL-R_CTRL-W) in _cmdline.txt_
* [\[I](https://vimhelp.org/tagsrch.txt.html#%5BI) in _tagsrch.txt_
* [\[_CTRL-I](https://vimhelp.org/tagsrch.txt.html#%5B_CTRL-I) in _tagsrch.txt_
```